### PR TITLE
Switch to using the liboctomap-dev key for a dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,9 +40,7 @@
   <depend>libboost-dev</depend>
   <depend>libboost-system-dev</depend>
   <depend>libboost-regex-dev</depend>
-  <!-- Octomap is an optional dependency. There seems to be an issue resolving
-    this key on the ROS buildfarm, so disabling it for now -->
-  <!-- <depend>octomap</depend> -->
+  <depend>liboctomap-dev</depend>
   <depend>lz4</depend>
 
   <test_depend>ament_cmake_xmllint</test_depend>


### PR DESCRIPTION
This is now available in rosdep.

See https://github.com/ros/rosdistro/pull/41623 .

To be perfectly frank, when I test built this locally, I didn't see much of a difference before and after this patch.  Regardless, if this is something that DART depends on, we should enable it here.