### PR TITLE
Add check for system installed dartsim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(gz_dartsim_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-find_package(DART 6 QUIET
+find_package(DART 6.13 QUIET
   CONFIG
   COMPONENTS
   collision-bullet
@@ -28,6 +28,7 @@ ament_vendor(${PROJECT_NAME}
 message("DART_FOUND: ${DART_FOUND}")
 message("DART_VERSION: ${DART_VERSION}")
 message("DART_INCLUDE_DIRS: ${DART_INCLUDE_DIRS}")
+message("DART_LIBRARIES: ${DART_LIBRARIES}")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,17 @@ project(gz_dartsim_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+find_package(DART 6 QUIET
+  CONFIG
+  COMPONENTS
+  collision-bullet
+  collision-ode
+  utils
+  utils-urdf
+)
+
 ament_vendor(${PROJECT_NAME}
+  SATISFIED ${DART_FOUND}
   VCS_URL https://github.com/dartsim/dart.git
   VCS_VERSION v6.13.2
   CMAKE_ARGS
@@ -14,6 +24,10 @@ ament_vendor(${PROJECT_NAME}
   GLOBAL_HOOK
   PATCHES patches
 )
+
+message("DART_FOUND: ${DART_FOUND}")
+message("DART_VERSION: ${DART_VERSION}")
+message("DART_INCLUDE_DIRS: ${DART_INCLUDE_DIRS}")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,44 @@
 cmake_minimum_required(VERSION 3.10)
 project(gz_dartsim_vendor)
 
+# Project-specific settings
+set(LIB_VER_MAJOR 6)
+set(LIB_VER_MINOR 13)
+set(LIB_VER_PATCH 2)
+
+# Derived variables
+set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-find_package(DART 6.13 QUIET
+# Set the VERSION_MATCH to "EXACT" by default, but relax the requirement
+# if we are users are building from source (determined by the
+# GZ_BUILD_FROM_SOURCE environment variable) or if explicitly told to do so
+# by the GZ_RELAX_VERSION_MATCH environment variable.
+set(VERSION_MATCH "EXACT")
+if(NOT $ENV{GZ_BUILD_FROM_SOURCE} STREQUAL "")
+  set(VERSION_MATCH "")
+endif()
+
+if(NOT $ENV{GZ_RELAX_VERSION_MATCH} STREQUAL "")
+  set(VERSION_MATCH "")
+endif()
+
+find_package(DART ${VERSION_MATCH} ${LIB_VER_MAJOR}.${LIB_VER_MINOR}
   CONFIG
   COMPONENTS
   collision-bullet
   collision-ode
   utils
   utils-urdf
+  QUIET
 )
 
 ament_vendor(${PROJECT_NAME}
   SATISFIED ${DART_FOUND}
   VCS_URL https://github.com/dartsim/dart.git
-  VCS_VERSION v6.13.2
+  VCS_VERSION v${LIB_VER}
   CMAKE_ARGS
     -DDART_BUILD_GUI_OSG:BOOL=FALSE
     -DDART_BUILD_DARTPY:BOOL=FALSE
@@ -25,10 +47,10 @@ ament_vendor(${PROJECT_NAME}
   PATCHES patches
 )
 
-message("DART_FOUND: ${DART_FOUND}")
-message("DART_VERSION: ${DART_VERSION}")
-message("DART_INCLUDE_DIRS: ${DART_INCLUDE_DIRS}")
-message("DART_LIBRARIES: ${DART_LIBRARIES}")
+message(VERBOSE "DART_FOUND: ${DART_FOUND}")
+message(VERBOSE "DART_VERSION: ${DART_VERSION}")
+message(VERBOSE "DART_INCLUDE_DIRS: ${DART_INCLUDE_DIRS}")
+message(VERBOSE "DART_LIBRARIES: ${DART_LIBRARIES}")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
- Add support for system ogre installation
- Add exact/inexact version matching like the other vendor libs

Note that find_package looks for major.minor currently for exact matching, but major.minor.patch can be used if desired.

Closes #4 
