### PR TITLE
Bump dart vendor in rolling to 6.16.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(gz_dartsim_vendor)
 
 # Project-specific settings
 set(LIB_VER_MAJOR 6)
-set(LIB_VER_MINOR 13)
-set(LIB_VER_PATCH 2)
+set(LIB_VER_MINOR 16)
+set(LIB_VER_PATCH 6)
 
 # Derived variables
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   -->
   <version>0.1.2</version>
   <description>
-    Vendor package for the DART physics engine v6.13.2
+    Vendor package for the DART physics engine v6.16.6
   </description>
 
   <maintainer email="addisu@intrinsic.ai">Addisu Taddese</maintainer>

--- a/patches/0001-Fix-pkgconfig-installation-so-it-works-with-CMAKE_ST.patch
+++ b/patches/0001-Fix-pkgconfig-installation-so-it-works-with-CMAKE_ST.patch
@@ -1,4 +1,3 @@
-From d05efd325c779944ca351c0354b000851ba17da5 Mon Sep 17 00:00:00 2001
 From: "Addisu Z. Taddese" <addisu@openrobotics.org>
 Date: Fri, 29 Mar 2024 15:00:46 -0500
 Subject: [PATCH] Fix pkgconfig installation so it works with
@@ -6,20 +5,21 @@ Subject: [PATCH] Fix pkgconfig installation so it works with
 
 Signed-off-by: Addisu Z. Taddese <addisu@openrobotics.org>
 ---
- CMakeLists.txt | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index acdfebf..2700b44 100644
+index f3fe251..df820b0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -473,10 +473,11 @@ install(
- # Generate the DART pkg-config
- set(PC_CONFIG_IN ${DART_SOURCE_DIR}/cmake/dart.pc.in)
- set(PC_CONFIG_OUT ${DART_BINARY_DIR}/cmake/dart.pc)
--set(PC_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-+set(PC_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-+set(PC_CONFIG_INSTALL_ABS_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+@@ -529,13 +529,14 @@ if(ABSOLUTE_CMAKE_INSTALL_LIBDIR)
+ else()
+   # When "CMAKE_INSTALL_*DIR" are relative, we should ensure the installed
+   # files contain relocatable references to install paths.
+-  set(PC_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++  set(PC_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++  set(PC_CONFIG_INSTALL_ABS_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+   set(PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+   set(PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ endif()
  file(RELATIVE_PATH
    RELATIVE_PATH_TO_INSTALL_PREFIX
 -  "${PC_CONFIG_INSTALL_DIR}"
@@ -27,6 +27,3 @@ index acdfebf..2700b44 100644
    "${CMAKE_INSTALL_PREFIX}"
  )
  if(DART_VERBOSE)
--- 
-2.43.0
-


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-physics/issues/816 .

Should bring Jazzy users the version 6.16.6