### PR TITLE
Fix Clang 16+ build failure: suppress -Wnontrivial-memcall in imgui headers

### DIFF
--- a/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
+++ b/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
@@ -1,12 +1,21 @@
 diff --git a/dart/external/imgui/imgui.h b/dart/external/imgui/imgui.h
 --- a/dart/external/imgui/imgui.h
 +++ b/dart/external/imgui/imgui.h
-@@ -118,6 +118,9 @@ typedef void* ImTextureID;          // User data for rendering backend to identi
- #pragma clang diagnostic push
- #pragma clang diagnostic ignored "-Wold-style-cast"
+@@ -120,4 +120,7 @@ typedef void* ImTextureID;          // User data for rendering backend to identi
  #if __has_warning("-Wzero-as-null-pointer-constant")
  #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
  #endif
++#if __has_warning("-Wnontrivial-memcall")
++#pragma clang diagnostic ignored "-Wnontrivial-memcall"  // memset(this, 0, ...) on non-trivially copyable types
++#endif
+ #elif defined(__GNUC__)
+diff --git a/dart/external/imgui/imgui_internal.h b/dart/external/imgui/imgui_internal.h
+--- a/dart/external/imgui/imgui_internal.h
++++ b/dart/external/imgui/imgui_internal.h
+@@ -82,4 +82,7 @@ typedef void* ImTextureID;
+ #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+ #pragma clang diagnostic ignored "-Wdouble-promotion"
+ #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
 +#if __has_warning("-Wnontrivial-memcall")
 +#pragma clang diagnostic ignored "-Wnontrivial-memcall"  // memset(this, 0, ...) on non-trivially copyable types
 +#endif

--- a/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
+++ b/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
@@ -1,22 +1,15 @@
-diff --git a/dart/external/imgui/imgui.h b/dart/external/imgui/imgui.h
---- a/dart/external/imgui/imgui.h
-+++ b/dart/external/imgui/imgui.h
-@@ -120,4 +120,7 @@ typedef void* ImTextureID;          // User data for rendering backend to identi
- #if __has_warning("-Wzero-as-null-pointer-constant")
- #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
- #endif
-+#if __has_warning("-Wnontrivial-memcall")
-+#pragma clang diagnostic ignored "-Wnontrivial-memcall"  // memset(this, 0, ...) on non-trivially copyable types
-+#endif
- #elif defined(__GNUC__)
-diff --git a/dart/external/imgui/imgui_internal.h b/dart/external/imgui/imgui_internal.h
---- a/dart/external/imgui/imgui_internal.h
-+++ b/dart/external/imgui/imgui_internal.h
-@@ -82,4 +82,7 @@ typedef void* ImTextureID;
- #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
- #pragma clang diagnostic ignored "-Wdouble-promotion"
- #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
-+#if __has_warning("-Wnontrivial-memcall")
-+#pragma clang diagnostic ignored "-Wnontrivial-memcall"  // memset(this, 0, ...) on non-trivially copyable types
-+#endif
- #elif defined(__GNUC__)
+diff --git a/dart/external/imgui/CMakeLists.txt b/dart/external/imgui/CMakeLists.txt
+--- a/dart/external/imgui/CMakeLists.txt
++++ b/dart/external/imgui/CMakeLists.txt
+@@ -21,4 +21,11 @@
+ if(CMAKE_COMPILER_IS_GNUCXX)
+   target_compile_options(${target_name} PRIVATE -w)
+ endif()
++if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++  include(CheckCXXCompilerFlag)
++  check_cxx_compiler_flag("-Wnontrivial-memcall" COMPILER_HAS_WNONTRIVIAL_MEMCALL)
++  if(COMPILER_HAS_WNONTRIVIAL_MEMCALL)
++    target_compile_options(${target_name} PRIVATE -Wno-nontrivial-memcall)
++  endif()
++endif()
+ target_compile_definitions(${target_name} PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)

--- a/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
+++ b/patches/0002-fix-imgui-nontrivial-memcall-clang.patch
@@ -1,0 +1,13 @@
+diff --git a/dart/external/imgui/imgui.h b/dart/external/imgui/imgui.h
+--- a/dart/external/imgui/imgui.h
++++ b/dart/external/imgui/imgui.h
+@@ -118,6 +118,9 @@ typedef void* ImTextureID;          // User data for rendering backend to identi
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wold-style-cast"
+ #if __has_warning("-Wzero-as-null-pointer-constant")
+ #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+ #endif
++#if __has_warning("-Wnontrivial-memcall")
++#pragma clang diagnostic ignored "-Wnontrivial-memcall"  // memset(this, 0, ...) on non-trivially copyable types
++#endif
+ #elif defined(__GNUC__)


### PR DESCRIPTION
## Problem

Building `gz_dartsim_vendor` with Clang 16+ fails due to `-Wnontrivial-memcall` being
treated as an error. The warning is triggered by `memset(this, 0, ...)` calls on
non-trivially copyable types inside DART's vendored imgui source (`imgui.h`,
`imgui_internal.h`).

Example error:

```
error: undefined behavior: call to 'memset' on an object of type '...' that is not
TriviallyCopyable [-Werror,-Wnontrivial-memcall]
```

## Fix

Adds `-Wno-nontrivial-memcall` to the imgui target's compile options via CMake, guarded
by `CheckCXXCompilerFlag` so it only applies when the compiler actually supports the
warning. This is the CMake equivalent of `__has_warning` and ensures older Clang versions
that don't recognise the flag are unaffected.

```diff
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-Wnontrivial-memcall" COMPILER_HAS_WNONTRIVIAL_MEMCALL)
+  if(COMPILER_HAS_WNONTRIVIAL_MEMCALL)
+    target_compile_options(${target_name} PRIVATE -Wno-nontrivial-memcall)
+  endif()
+endif()
```

## Files Changed

- `patches/0002-fix-imgui-nontrivial-memcall-clang.patch` — new patch applied to DART's
  vendored imgui headers (`imgui.h` and `imgui_internal.h`)

## Tested On

- macOS (Apple Silicon), Clang 16+
- `colcon build --packages-select gz_dartsim_vendor` passes cleanly
